### PR TITLE
Specs for client::auth_mode, client::permitted_peer, rsyslog::local_hostname

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -72,6 +72,12 @@ class rsyslog::client (
     fail('You need to enable tcp in order to use SSL.')
   }
 
-  # include testing for $auth_mode and $permitted_peer
+  if $auth_mode and $rsyslog::ssl == false {
+    fail('You need to enable SSL in order to use $auth_mode.')
+  }
+
+  if $permitted_peer and $auth_mode == undef {
+    fail('$auth_mode must be defined in order to use $permitted_peer.')
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class rsyslog (
   $rsyslog_default_file   = $rsyslog::params::default_config_file,
   $run_user               = $rsyslog::params::run_user,
   $run_group              = $rsyslog::params::run_group,
-  $LocalHostName          = undef,
+  $local_hostname         = undef,
   $log_user               = $rsyslog::params::log_user,
   $log_group              = $rsyslog::params::log_group,
   $log_style              = $rsyslog::params::log_style,

--- a/spec/classes/rsyslog_client_spec.rb
+++ b/spec/classes/rsyslog_client_spec.rb
@@ -42,6 +42,79 @@ describe 'rsyslog::client', :type => :class do
           should contain_file('/etc/rsyslog.d/client.conf')
         end
       end
+
+      context "auth_mode (osfamily = Debian)" do
+
+        let(:title) { 'rsyslog-client-auth_mode' }
+
+        context "without SSL" do
+          let(:params) { { :auth_mode => 'x509/name' } }
+          it 'should fail' do
+            expect { should contain_class('rsyslog::client') }
+              .to raise_error(Puppet::Error, /You need to enable SSL in order to use \$auth_mode./)
+          end
+        end
+
+        context "with SSL" do
+          let :pre_condition do
+            "class { 'rsyslog': ssl => true }"
+          end
+
+          ssl_params = { :ssl_ca => '/tmp/cert.pem' }
+
+          context "with default auth_mode" do
+            let(:params) { ssl_params }
+
+            it 'should compile' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode anon/)
+                .without_content(/\$ActionSendStreamDriverPermittedPeer/)
+            end
+          end
+
+          context "without permitted peer" do
+            let(:params) do
+              ssl_params.merge({
+                :auth_mode => 'x509/name',
+              })
+            end
+
+            it 'should contain ActionSendStreamDriverAuthMode' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode x509\/name/)
+                .without_content(/\$ActionSendStreamDriverPermittedPeer/)
+            end
+          end
+
+          context "permitted peer with anon auth_mode" do
+            let(:params) do
+              ssl_params.merge({
+                :permitted_peer => 'logs.example.com'
+              })
+            end
+
+            it 'should fail' do
+              expect { should contain_class('rsyslog::client') }
+                .to raise_error(Puppet::Error, /\$auth_mode must be defined in order to use \$permitted_peer./)
+            end
+          end
+
+          context "with permitted peer" do
+            let(:params) do
+              ssl_params.merge({
+                :auth_mode      => 'x509/name',
+                :permitted_peer => 'logs.example.com'
+              })
+            end
+
+            it 'should contain ActionSendStreamDriverPermittedPeer' do
+              should contain_file('/etc/rsyslog.d/client.conf')
+                .with_content(/\$ActionSendStreamDriverAuthMode x509\/name/)
+                .with_content(/\$ActionSendStreamDriverPermittedPeer logs.example.com/) 
+            end
+          end
+        end
+      end
     end
 
     context "osfamily = FreeBSD" do

--- a/spec/classes/rsyslog_spec.rb
+++ b/spec/classes/rsyslog_spec.rb
@@ -46,6 +46,26 @@ describe 'rsyslog', :type => :class do
           should contain_class('rsyslog::service')
         end
       end
+
+      context "local hostname (osfamily = Debian)" do
+        let(:title) { 'rsyslog-local-hostname' }
+
+        context "with defaults" do
+          it 'is not set' do
+            should contain_file('/etc/rsyslog.conf')
+              .without_content(/\$LocalHostName/)
+          end
+        end
+
+        context "when set" do
+          let(:params) { { :local_hostname => 'example.dev' } }
+
+          it 'should compile' do
+            should contain_file('/etc/rsyslog.conf')
+              .with_content(/\$LocalHostName example.dev/)
+          end
+        end
+      end
     end
   
     context "osfamily = FreeBSD" do

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -53,13 +53,13 @@ $DefaultNetstreamDriverCAFile <%= scope.lookupvar('rsyslog::client::ssl_ca') %>
 # Connection settings.
 $DefaultNetstreamDriver gtls
 $ActionSendstreamDriverMode 1
-<% if scope.lookupvar('rsyslog::client::auth_mode') -%>
-$ActionSendStreamDriverAuthMode <%= scope.lookupvar('rsyslog::client::auth_mode') %>
+<% if @auth_mode -%>
+$ActionSendStreamDriverAuthMode <%= @auth_mode %>
+<% if @permitted_peer -%>
+$ActionSendStreamDriverPermittedPeer <%= @permitted_peer %>
+<% end -%>
 <% else -%>
 $ActionSendStreamDriverAuthMode anon
-<% end -%>
-<% if scope.lookupvar('rsyslog::client::auth_mode') == 'x509/name' -%>
-$ActionSendStreamDriverPermittedPeer <%= scope.lookupvar('rsyslog::client::permitted_peer') %>
 <% end -%>
 <% end -%>
 

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -2,8 +2,8 @@
 <% if scope.lookupvar('rsyslog::preserve_fqdn') -%>
 $PreserveFQDN on
 <% end -%>
-<% if scope.lookupvar('rsyslog::LocalHostName') -%>
-$LocalHostName <%= scope.lookupvar('rsyslog::LocalHostName') %>
+<% if @local_hostname -%>
+$LocalHostName <%= @local_hostname %>
 <% end -%>
 #################
 #### MODULES ####


### PR DESCRIPTION
Specs for your changes.

Notes:

- I had to modify the `scope.lookupvar` calls in the template to use instance variables instead, otherwise lines would always get added to the file, even if their value was `undef`. Note, too, that this is more in-line with Puppet's recommendations for referencing variables: https://docs.puppetlabs.com/guides/templating.html#referencing-variables
- I renamed `rsyslog::LocalHostName` to `rsyslog::local_hostname` for two reasons:  1) ruby doesn't like symbols that begin with a capital letter, and 2) it matches the syntax of the rest of the configuration parameters.
